### PR TITLE
Feature/merkle extend

### DIFF
--- a/include/ametsuchi/buffer.h
+++ b/include/ametsuchi/buffer.h
@@ -60,6 +60,22 @@ class CircularStack {
    */
   void pop(size_t n = 1);
 
+
+  /**
+   * O(1)
+   * Accessing element by front.
+   */
+  T &front();
+  T front() const;
+
+  /**
+   * O(1)
+   * Accessing element by back.
+   */
+  T &back();
+  T back() const;
+
+
   /**
    * O(1)
    * Accessing element by index
@@ -90,7 +106,7 @@ class CircularStack {
 
   // Determines n position before p
   constexpr size_t diff(size_t p, size_t n) const {
-    return p < n ? p + size() - n : p - n;
+    return p < n ? p + capacity() - n : p - n;
   }
 
   constexpr size_t overflowed() { return capacity(); }

--- a/include/ametsuchi/buffer.inc
+++ b/include/ametsuchi/buffer.inc
@@ -59,7 +59,31 @@ void CircularStack<T>::push(const T &t) {
 
 template <typename T>
 void CircularStack<T>::pop(size_t n) {
-  sz = size() < n ? 0 : size() - n;
+  n = std::min( sz, n );
+  sz = sz - n;
+  i_end = (i_end + capacity() - n) % capacity();
+}
+
+template <typename T>
+T &CircularStack<T>::front() {
+  if (size()==0) throw Exception("Buffer accessing out of size");
+  return v[diff(i_end, size())];
+}
+template <typename T>
+T CircularStack<T>::front() const {
+  if (size()==0) throw Exception("Buffer accessing out of size");
+  return v[diff(i_end, size())];
+}
+
+template <typename T>
+T &CircularStack<T>::back() {
+  if (size()==0) throw Exception("Buffer accessing out of size");
+  return v[diff(i_end, 1)];
+}
+template <typename T>
+T CircularStack<T>::back() const {
+  if (size()==0) throw Exception("Buffer accessing out of size");
+  return v[diff(i_end, 1)];
 }
 
 template <typename T>

--- a/include/ametsuchi/index/merkle.h
+++ b/include/ametsuchi/index/merkle.h
@@ -238,21 +238,20 @@ size_t NarrowMerkleTree<T>::drop(size_t ind) {
   if( previous_drop_number >= ind ) return ind;
   size_t id_tx = txs;
   size_t cap = 1, xcap = capacity();
-  size_t ret = ind; bool upd_flag = false;
+  bool upd_flag = false; txs = ind;
   for( auto layer = data.begin(); layer != data.end(); ++layer ) {
     size_t num = ( id_tx % ( cap * xcap ) )/cap;
     size_t rm_num = std::min( layer->size(), (id_tx - ind + cap - 1)/cap );
     layer->pop( rm_num );
     if( !upd_flag && layer->size() ) {
-      ret = id_tx - rm_num * cap;
+      txs = id_tx - rm_num * cap;
       upd_flag = true;
     }
     id_tx -= num * cap;
     cap *= xcap;
   }
-  txs = ret;
-  previous_drop_number = ret;
-  return ret;
+  previous_drop_number = txs;
+  return txs;
 }
 
 template <typename T>

--- a/include/ametsuchi/index/merkle.h
+++ b/include/ametsuchi/index/merkle.h
@@ -205,7 +205,6 @@ void NarrowMerkleTree<T>::add(T t) {
   txs++;
   // Cumulative sum of Hash
   data[0].push( hash( get_root(), t ) );
-  bool extend_tx = true;
   if (txs != 1 && height(txs) > height(txs - 1) && height(txs) > data.size() ) {
     grow();
   }
@@ -220,15 +219,22 @@ void NarrowMerkleTree<T>::add(T t) {
   for( auto child = data.begin(), parent = child+1; parent != data.end();
       ++child, ++parent, layer_idx /= capacity() ) {
     // child extend and right most node
-    if( extend_tx && layer_idx % capacity() == capacity()-1 ) {
+    if( layer_idx % capacity() == capacity()-1 ) {
       parent->push( child->back() );
     } else
-      extend_tx = false;
+      break;
   }
 }
 
 template <typename T>
 size_t NarrowMerkleTree<T>::drop(size_t ind) {
+  if( ind == 0 ) {
+    data.clear();
+    previous_drop_number = 0;
+    txs = 0;
+    data.emplace_back( capacity() );
+    return 0;
+  }
   if( previous_drop_number >= ind ) return ind;
   size_t id_tx = txs;
   size_t cap = 1, xcap = capacity();

--- a/test/ametsuchi/buffer_test.cc
+++ b/test/ametsuchi/buffer_test.cc
@@ -17,6 +17,7 @@
 
 #include <ametsuchi/buffer.h>
 #include <gtest/gtest.h>
+#include <stack>
 
 namespace ametsuchi {
 namespace buffer {
@@ -129,6 +130,29 @@ TEST(CircularStack, IterForEach) {
     cs[1];
   } catch (Exception &e) {
     ASSERT_STREQ(e.what(), "Buffer accessing out of size");
+  }
+}
+
+TEST(CirularStack, PushAndPopAndFront ) {
+  auto size = 10;
+  std::stack<int> st;
+  CircularStack<uint64_t> cs(size);
+  for(auto i = 0; i < size-1; i++ ) {
+    st.push(i);
+    cs.push(i);
+  }
+
+  for(auto i=0; i < 5; i++ ) {
+    ASSERT_EQ( st.top(), cs.back() );
+    st.pop(); cs.pop();
+  }
+  for(auto i = 0; i < 5; i++ ) {
+    st.push(i+size);
+    cs.push(i+size);
+  }
+  while( !st.empty() ){
+    ASSERT_EQ( st.top(), cs.back() );
+    st.pop(); cs.pop();
   }
 }
 

--- a/test/ametsuchi/index/merkle_test.cc
+++ b/test/ametsuchi/index/merkle_test.cc
@@ -51,7 +51,7 @@ TEST(Merkle, Addition) {
 TEST(Merkle, Dropping) {
   NarrowMerkleTree<uint64_t> tree([](auto i, auto j) { return i + j; });
   for (auto i = 0; i < size; ++i) tree.add(i);
-  tree.drop(8);
+  tree.drop(6);
   /*
    * data[3]:(0+1 + 2+3  +  4+5 + 6+7)
    * data[2]:(0+1 + 2+3)   (4+5 + 6+7)
@@ -59,19 +59,6 @@ TEST(Merkle, Dropping) {
    * data[0]:                           8 9
    *   ||
    *   v
-   * data[3]:(0+1 + 2+3  +  4+5 + 6+7)
-   * data[2]:(0+1 + 2+3)   (4+5 + 6+7)
-   * data[1]:                    (6+7)
-   * data[0]:
-   */
-  ASSERT_EQ(tree.size(), 8);
-  ASSERT_EQ(tree.get_root(), 7*8/2 );
-
-  for(auto i=8;i<size;i++) tree.add(i);
-  ASSERT_EQ(tree.size(), size);
-  ASSERT_EQ(tree.get_root(),9*10/2);
-  tree.drop(6);
-  /*
    * data[3]:
    * data[2]:(0+1 + 2+3)
    * data[1]:
@@ -83,26 +70,55 @@ TEST(Merkle, Dropping) {
   for(auto i=4;i<size;i++) tree.add(i);
   ASSERT_EQ(tree.size(), size);
   ASSERT_EQ(tree.get_root(),9*10/2);
-  tree.drop(0);
-  ASSERT_EQ(tree.size(), 0);
+
+  tree.drop(8);
+  /*
+   * data[3]:(0+1 + 2+3  +  4+5 + 6+7)
+   * data[2]:(0+1 + 2+3)   (4+5 + 6+7)
+   * data[1]:                    (6+7)
+   * data[0]:
+   */
+  ASSERT_EQ(tree.size(), 8);
+  ASSERT_EQ(tree.get_root(), 7*8/2 );
+
+  for(auto i=8;i<size;i++) tree.add(i);
+  ASSERT_EQ(tree.size(), size);
+  ASSERT_EQ(tree.get_root(),9*10/2);
+
 
 }
 
-TEST(Merkle, Statics) {
+TEST(Merkle, Hegiht) {
   {
     constexpr size_t heights[] = {
         0,
         1,
-        2,
-        3, 3,
-        4, 4, 4, 4,
-        5, 5, 5, 5, 5, 5, 5, 5,
-        6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,};
+        2, 2,
+        3, 3, 3, 3,
+        4, 4, 4, 4, 4, 4, 4, 4,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+        6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6 };
     constexpr auto elems = sizeof(heights) / sizeof(heights[0]);
+    NarrowMerkleTree<uint64_t> tree([](auto i, auto j) { return i + j; }, 2);
     for (size_t i = 0; i < elems; ++i) {
-      ASSERT_EQ(NarrowMerkleTree<uint64_t>::height(i), heights[i]);
+      ASSERT_EQ(tree.height(i), heights[i]);
     }
   }
+  {
+    constexpr size_t heights[] = {
+        0,
+        1, 1, 1,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+    constexpr auto elems = sizeof(heights) / sizeof(heights[0]);
+    NarrowMerkleTree<uint64_t> tree([](auto i, auto j) { return i + j; }, 4);
+    for (size_t i = 0; i < elems; ++i) {
+      ASSERT_EQ(tree.height(i), heights[i]);
+    }
+  }
+}
+
+TEST(Merkle, Statics) {
   {
     constexpr size_t diffs[] = {0, 0, 1, 0, 2, 1, 2, 0, 3, 2, 3, 1, 3, 2, 3, 0, 4};
     constexpr auto elems = sizeof(diffs) / sizeof(diffs[0]);
@@ -112,6 +128,41 @@ TEST(Merkle, Statics) {
   }
 }
 
+TEST(Merkle, ExtendAddition) {
+  NarrowMerkleTree<uint64_t> tree([](auto i, auto j) { return i + j; },8);
+  /*
+   *                              55
+   *              28                           27
+   *       6              22              27
+   *   1       5       9      13      17       10
+   * 0   1   2   3   4   5   6   7   8   9   10
+   */
+  for (size_t i = 0, sum = 0; i < size * size; ++i, sum += i) {
+    tree.add(i);
+    ASSERT_EQ(tree.get_root(), sum);
+  }
+}
+
+TEST(Merkle, ExtendDropping) {
+  NarrowMerkleTree<uint64_t> tree([](auto i, auto j) { return i + j; },8);
+  for (auto i = 0; i < size; ++i) tree.add(i);
+  tree.drop(6);
+  ASSERT_EQ(tree.size(),6);
+  ASSERT_EQ(tree.get_root(), 5*6/2);
+
+  for(auto i=6;i<size;i++) tree.add(i);
+  ASSERT_EQ(tree.size(), size);
+  ASSERT_EQ(tree.get_root(),9*10/2);
+
+  tree.drop(8);
+  ASSERT_EQ(tree.size(), 8);
+  ASSERT_EQ(tree.get_root(), 7*8/2 );
+
+  for(auto i=8;i<size;i++) tree.add(i);
+  ASSERT_EQ(tree.size(), size);
+  ASSERT_EQ(tree.get_root(),9*10/2);
+
+}
 
 
 }  // namespace merkle

--- a/test/ametsuchi/index/merkle_test.cc
+++ b/test/ametsuchi/index/merkle_test.cc
@@ -85,6 +85,9 @@ TEST(Merkle, Dropping) {
   ASSERT_EQ(tree.size(), size);
   ASSERT_EQ(tree.get_root(),9*10/2);
 
+  tree.drop(0);
+  ASSERT_EQ(tree.size(),0);
+
 
 }
 
@@ -161,6 +164,9 @@ TEST(Merkle, ExtendDropping) {
   for(auto i=8;i<size;i++) tree.add(i);
   ASSERT_EQ(tree.size(), size);
   ASSERT_EQ(tree.get_root(),9*10/2);
+
+  tree.drop(0);
+  ASSERT_EQ(tree.size(),0);
 
 }
 

--- a/test/ametsuchi/index/merkle_test.cc
+++ b/test/ametsuchi/index/merkle_test.cc
@@ -51,9 +51,41 @@ TEST(Merkle, Addition) {
 TEST(Merkle, Dropping) {
   NarrowMerkleTree<uint64_t> tree([](auto i, auto j) { return i + j; });
   for (auto i = 0; i < size; ++i) tree.add(i);
-  tree.drop(2);
-  ASSERT_LE(tree.size(), size);
-  ASSERT_GE(tree.size(), 0);
+  tree.drop(8);
+  /*
+   * data[3]:(0+1 + 2+3  +  4+5 + 6+7)
+   * data[2]:(0+1 + 2+3)   (4+5 + 6+7)
+   * data[1]:                    (6+7) (8+9)
+   * data[0]:                           8 9
+   *   ||
+   *   v
+   * data[3]:(0+1 + 2+3  +  4+5 + 6+7)
+   * data[2]:(0+1 + 2+3)   (4+5 + 6+7)
+   * data[1]:                    (6+7)
+   * data[0]:
+   */
+  ASSERT_EQ(tree.size(), 8);
+  ASSERT_EQ(tree.get_root(), 7*8/2 );
+
+  for(auto i=8;i<size;i++) tree.add(i);
+  ASSERT_EQ(tree.size(), size);
+  ASSERT_EQ(tree.get_root(),9*10/2);
+  tree.drop(6);
+  /*
+   * data[3]:
+   * data[2]:(0+1 + 2+3)
+   * data[1]:
+   * data[0]:
+   */
+  ASSERT_EQ(tree.size(),4);
+  ASSERT_EQ(tree.get_root(), 3*4/2);
+
+  for(auto i=4;i<size;i++) tree.add(i);
+  ASSERT_EQ(tree.size(), size);
+  ASSERT_EQ(tree.get_root(),9*10/2);
+  tree.drop(0);
+  ASSERT_EQ(tree.size(), 0);
+
 }
 
 TEST(Merkle, Statics) {


### PR DESCRIPTION
# Merkle Tree Extend

This merkle tree has `cumulation hash`.

## order
Memory order : log_capacity( node ) * capacity
add : O( log_capacity( node ) )
get_root : O( log_capacity( node ) )
drop: O( log_capacity( node ) * capacity )

## Restriction
 - drop()'s argument is must be greater than num that is previous called.
 - Can only hash the coverage of the capacity.
    ( e.g, Roughly cover the whole )
 - **`hash` function must not have commutative property.**

## Change Point
 - fix CirucularStack
 - drop() / add() / get_root() 
 - add merkle test and buffer test