### PR TITLE
Fix/only lmdb asset test

### DIFF
--- a/cmake/Modules/FindLMDB.cmake
+++ b/cmake/Modules/FindLMDB.cmake
@@ -2,6 +2,8 @@ find_path(LMDB_INCLUDE_DIRS lmdb.h)
 
 find_library(LMDB_LIBRARIES lmdb)
 
+#TODO check version
+
 find_package(PackageHandleStandardArgs REQUIRED)
 find_package_handle_standard_args(LMDB
   REQUIRED_VARS LMDB_INCLUDE_DIRS LMDB_LIBRARIES

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -167,12 +167,12 @@ endif()
 ###########################
 #         LMDB            #
 ###########################
-find_package(LMDB)
+#find_package(LMDB)
 
 if(NOT LMDB_FOUND)
   ExternalProject_Add(lmdb_LMDB
     GIT_REPOSITORY    "https://github.com/LMDB/lmdb.git"
-    GIT_TAG           "mdb.master"
+    GIT_TAG           "LMDB_0.9.19"
     CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE   1
     BUILD_COMMAND     cd libraries/liblmdb && $(MAKE) liblmdb.a CC="${CMAKE_C_COMPILER}"

--- a/include/ametsuchi/common.h
+++ b/include/ametsuchi/common.h
@@ -52,8 +52,8 @@ inline std::pair<MDB_dbi, MDB_cursor*> init_btree(MDB_txn* append_tx, const std:
 }
 
 /**
- * Represents a value, readed from a database.
- * Used to restrict changing of mmaped data by pointer.
+ * Represents a value read from a database.
+ * Used to prohibit changes of mmaped data by pointer.
  */
 struct AM_val {
   // pointer, which points to blob with data

--- a/include/ametsuchi/wsv.h
+++ b/include/ametsuchi/wsv.h
@@ -31,6 +31,11 @@ class WSV {
   WSV();
   ~WSV();
 
+  enum ACCOUNT_UPDATE_STATE {
+    ADD,
+    SUB
+  };
+
   void update(const std::vector<uint8_t> *blob);
 
   void init(MDB_txn *append_tx);
@@ -82,7 +87,11 @@ class WSV {
   void account_remove(const iroha::AccountRemove *command);
   void peer_add(const iroha::PeerAdd *command);
   void peer_remove(const iroha::PeerRemove *command);
-  // manipulate with account's assets using these functions
+  // manipulate with account's assets using these function
+  void account_update_currency(const flatbuffers::String *acc_pub_key,
+                               const iroha::Asset *asset,
+                               const flatbuffers::Vector<uint8_t> *,
+                               ACCOUNT_UPDATE_STATE state);
   void account_add_currency(const flatbuffers::String *acc_pub_key,
                             const iroha::Currency *c, size_t c_size);
   void account_remove_currency(const flatbuffers::String *acc_pub_key,

--- a/include/ametsuchi/wsv.h
+++ b/include/ametsuchi/wsv.h
@@ -31,11 +31,6 @@ class WSV {
   WSV();
   ~WSV();
 
-  enum ACCOUNT_UPDATE_STATE {
-    ADD,
-    SUB
-  };
-
   void update(const std::vector<uint8_t> *blob);
 
   void init(MDB_txn *append_tx);
@@ -55,7 +50,7 @@ class WSV {
   AM_val accountGetAsset(const flatbuffers::String *pubKey,
                          const flatbuffers::String *ledger_name,
                          const flatbuffers::String *domain_name,
-                         const flatbuffers::String *asset_name, bool uncommitted = true,
+                         const flatbuffers::String *asset_name, bool uncommitted = false,
                          MDB_env *env = nullptr);
 
 
@@ -87,15 +82,11 @@ class WSV {
   void account_remove(const iroha::AccountRemove *command);
   void peer_add(const iroha::PeerAdd *command);
   void peer_remove(const iroha::PeerRemove *command);
-  // manipulate with account's assets using these function
-  void account_update_currency(const flatbuffers::String *acc_pub_key,
-                               const iroha::Asset *asset,
-                               const flatbuffers::Vector<uint8_t> *,
-                               ACCOUNT_UPDATE_STATE state);
+  // manipulate with account's assets using these functions
   void account_add_currency(const flatbuffers::String *acc_pub_key,
-                            const iroha::Currency *c, size_t c_size);
+                              const flatbuffers::Vector<uint8_t> *asset_fb);
   void account_remove_currency(const flatbuffers::String *acc_pub_key,
-                               const iroha::Currency *c);
+                               const flatbuffers::Vector<uint8_t> *asset_fb);
 };
 }
 

--- a/test/ametsuchi/ametsuchi.cc
+++ b/test/ametsuchi/ametsuchi.cc
@@ -68,18 +68,18 @@ TEST_F(Ametsuchi_Test, AssetTest) {
     );
     flatbuffers::GetRoot<iroha::Transaction>(blob.data());
     ametsuchi_.append(&blob);
-/*
+
     // Transfer from 1 to 2
     blob = generator::random_transaction(
         fbb, iroha::Command::AssetTransfer,
         generator::random_AssetTransfer(
             fbb,
-            generator::random_currency(100, 2, "Dollar", "USA", "l1"),
+            generator::random_asset_wrapper_currency(100, 2, "Dollar", "USA", "l1"),
             "1", "2").Union()
     );
     flatbuffers::GetRoot<iroha::Transaction>(blob.data());
     ametsuchi_.append(&blob);
     ametsuchi_.commit();
-*/
+
   //});
 }

--- a/test/ametsuchi/ametsuchi.cc
+++ b/test/ametsuchi/ametsuchi.cc
@@ -40,7 +40,6 @@ TEST_F(Ametsuchi_Test, AssetTest) {
     auto blob = generator::random_transaction(
         fbb, iroha::Command::AssetCreate,
         generator::random_AssetCreate(fbb, "Dollar", "USA", "l1").Union());
-    flatbuffers::GetRoot<iroha::Transaction>(blob.data());
     ametsuchi_.append(&blob);
 
     // Create account with id 1
@@ -48,7 +47,6 @@ TEST_F(Ametsuchi_Test, AssetTest) {
         fbb, iroha::Command::AccountAdd,
         generator::random_AccountAdd(fbb, generator::random_account("1")).Union()
     );
-    flatbuffers::GetRoot<iroha::Transaction>(blob.data());
     ametsuchi_.append(&blob);
 
     // Create account with id 2
@@ -56,7 +54,6 @@ TEST_F(Ametsuchi_Test, AssetTest) {
         fbb, iroha::Command::AccountAdd,
         generator::random_AccountAdd(fbb, generator::random_account("2")).Union()
     );
-    flatbuffers::GetRoot<iroha::Transaction>(blob.data());
     ametsuchi_.append(&blob);
 
     // Add currency to account 1
@@ -66,8 +63,17 @@ TEST_F(Ametsuchi_Test, AssetTest) {
             fbb, "1",
             generator::random_asset_wrapper_currency(200, 2, "Dollar", "USA", "l1")).Union()
     );
-    flatbuffers::GetRoot<iroha::Transaction>(blob.data());
     ametsuchi_.append(&blob);
+    auto tx =
+        flatbuffers::GetRoot<iroha::Transaction>(
+            blob.data());
+    auto cur = tx->command_as_AssetAdd()->asset_nested_root()->asset_as_Currency();
+    auto as =
+        flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
+            tx->command_as_AssetAdd()->accPubKey(), cur->ledger_name(), cur->domain_name(),
+            cur->currency_name(), true).data);
+    auto as_cur = as->asset_as_Currency();
+    ASSERT_EQ(as_cur->amount(), 200);
 
     // Transfer from 1 to 2
     blob = generator::random_transaction(
@@ -77,9 +83,30 @@ TEST_F(Ametsuchi_Test, AssetTest) {
             generator::random_asset_wrapper_currency(100, 2, "Dollar", "USA", "l1"),
             "1", "2").Union()
     );
-    flatbuffers::GetRoot<iroha::Transaction>(blob.data());
     ametsuchi_.append(&blob);
+    tx = flatbuffers::GetRoot<iroha::Transaction>(blob.data());
+    as = flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
+        tx->command_as_AssetTransfer()->sender(), cur->ledger_name(), cur->domain_name(),
+        cur->currency_name(), true).data);
+    as_cur = as->asset_as_Currency();
+    ASSERT_EQ(as_cur->amount(), 100);
+    as = flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
+      tx->command_as_AssetTransfer()->receiver(), cur->ledger_name(), cur->domain_name(),
+      cur->currency_name(), true).data);
+    as_cur = as->asset_as_Currency();
+    ASSERT_EQ(as_cur->amount(), 100);
+
     ametsuchi_.commit();
 
+    as = flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
+        tx->command_as_AssetTransfer()->sender(), cur->ledger_name(), cur->domain_name(),
+        cur->currency_name(), false).data);
+    as_cur = as->asset_as_Currency();
+    ASSERT_EQ(as_cur->amount(), 100);
+    as = flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
+        tx->command_as_AssetTransfer()->receiver(), cur->ledger_name(), cur->domain_name(),
+        cur->currency_name(), false).data);
+    as_cur = as->asset_as_Currency();
+    ASSERT_EQ(as_cur->amount(), 100);
   //});
 }

--- a/test/ametsuchi/ametsuchi.cc
+++ b/test/ametsuchi/ametsuchi.cc
@@ -34,7 +34,7 @@ class Ametsuchi_Test : public ::testing::Test {
 
 
 TEST_F(Ametsuchi_Test, AssetTest) {
- // ASSERT_NO_THROW({
+    // ASSERT_NO_THROW({
     flatbuffers::FlatBufferBuilder fbb(2048);
     // Create asset dollar
     auto blob = generator::random_transaction(
@@ -64,11 +64,11 @@ TEST_F(Ametsuchi_Test, AssetTest) {
         fbb, iroha::Command::AssetAdd,
         generator::random_AssetAdd(
             fbb, "1",
-            generator::random_currency(200, 2, "Dollar", "USA", "l1")).Union()
+            generator::random_asset_wrapper_currency(200, 2, "Dollar", "USA", "l1")).Union()
     );
     flatbuffers::GetRoot<iroha::Transaction>(blob.data());
     ametsuchi_.append(&blob);
-
+/*
     // Transfer from 1 to 2
     blob = generator::random_transaction(
         fbb, iroha::Command::AssetTransfer,
@@ -80,6 +80,6 @@ TEST_F(Ametsuchi_Test, AssetTest) {
     flatbuffers::GetRoot<iroha::Transaction>(blob.data());
     ametsuchi_.append(&blob);
     ametsuchi_.commit();
-
+*/
   //});
 }

--- a/test/generator/tx_generator.h
+++ b/test/generator/tx_generator.h
@@ -165,6 +165,28 @@ std::vector<uint8_t> random_currency(
   return {ptr, ptr + fbb.GetSize()};
 }
 
+std::vector<uint8_t> random_asset_wrapper_currency(
+    uint64_t amount = (uint64_t)random_number(1, 50),
+    uint8_t precision = (uint8_t)random_number(0, 3),
+    std::string currency_name = random_string(6),
+    std::string domain_name = DOMAIN_, std::string ledger_name = LEDGER_,
+    std::string description = random_string((size_t)random_number(5, 100))) {
+  flatbuffers::FlatBufferBuilder fbb(2048);
+
+  auto asset = iroha::CreateAsset(
+      fbb,
+      iroha::AnyAsset::Currency,
+      iroha::CreateCurrency(
+          fbb, fbb.CreateString(currency_name), fbb.CreateString(domain_name),
+          fbb.CreateString(ledger_name), fbb.CreateString(description), amount,
+          precision).Union());
+
+  fbb.Finish(asset);
+
+  uint8_t* ptr = fbb.GetBufferPointer();
+  return {ptr, ptr + fbb.GetSize()};
+}
+
 
 flatbuffers::Offset<iroha::Signature> random_signature(
     flatbuffers::FlatBufferBuilder& fbb,
@@ -193,7 +215,7 @@ flatbuffers::Offset<iroha::AccountRemove> random_AccountRemove(
 flatbuffers::Offset<iroha::AssetAdd> random_AssetAdd(
     flatbuffers::FlatBufferBuilder& fbb,
     std::string accPubKey = random_public_key(),
-    std::vector<uint8_t> asset = random_currency()) {
+    std::vector<uint8_t> asset = random_asset_wrapper_currency()) {
   return iroha::CreateAssetAdd(fbb, fbb.CreateString(accPubKey),
                                fbb.CreateVector(asset));
 }
@@ -202,7 +224,7 @@ flatbuffers::Offset<iroha::AssetAdd> random_AssetAdd(
 flatbuffers::Offset<iroha::AssetRemove> random_AssetRemove(
     flatbuffers::FlatBufferBuilder& fbb,
     std::string accPubKey = random_public_key(),
-    std::vector<uint8_t> asset = random_currency()) {
+    std::vector<uint8_t> asset = random_asset_wrapper_currency()) {
   return iroha::CreateAssetRemove(fbb, fbb.CreateString(accPubKey),
                                   fbb.CreateVector(asset));
 }
@@ -220,7 +242,7 @@ flatbuffers::Offset<iroha::AssetCreate> random_AssetCreate(
 
 flatbuffers::Offset<iroha::AssetTransfer> random_AssetTransfer(
     flatbuffers::FlatBufferBuilder& fbb,
-    std::vector<uint8_t> asset = random_currency(),
+    std::vector<uint8_t> asset = random_asset_wrapper_currency(),
     std::string sender = random_public_key(),
     std::string receiver = random_public_key()) {
   return iroha::CreateAssetTransfer(fbb, fbb.CreateVector(asset),

--- a/test/generator/tx_generator.h
+++ b/test/generator/tx_generator.h
@@ -170,9 +170,16 @@ std::vector<uint8_t> random_asset_wrapper_currency(
     uint8_t precision = (uint8_t)random_number(0, 3),
     std::string currency_name = random_string(6),
     std::string domain_name = DOMAIN_, std::string ledger_name = LEDGER_,
-    std::string description = random_string((size_t)random_number(5, 100))) {
+    std::string description = random_string(0)) {
   flatbuffers::FlatBufferBuilder fbb(2048);
 
+  // May be erased commen :
+  /*
+   * Even though that two asset has same currency_name and domain_name and ledgername,
+   * not necessary two asset same size.
+   */
+  //printf("in rando gen\n");
+  //printf("%d %d %s %s %s %s\n",amount,precision,currency_name.c_str(),domain_name.c_str(),ledger_name.c_str(),description.c_str());
   auto asset = iroha::CreateAsset(
       fbb,
       iroha::AnyAsset::Currency,
@@ -184,6 +191,8 @@ std::vector<uint8_t> random_asset_wrapper_currency(
   fbb.Finish(asset);
 
   uint8_t* ptr = fbb.GetBufferPointer();
+  //printf("random_asset_wrapper_currency size: %d\n",fbb.GetSize());
+  //fflush(stdout);
   return {ptr, ptr + fbb.GetSize()};
 }
 


### PR DESCRIPTION
Passed `AssetTest` in `test/ametsuchi/ametsuchi.cc`.

## Change point
 - Unified `Currency` -> `Asset`, when mixed `Currency` and `Asset`
 - So make `create_asset_wrapper_currecy` in `tx_genrator.cc`
 - Unified `account_add_assets` and `account_remove_assets` -> `account_update_assets`.

## Problem
Plase read CAUTION in `wsv.cc`.
~~I look flatbuffer has optimal different size nevertheless it has same type. (for example : ( `uint64_t : 200` and `uint64_t : 0` is not size )~~
`ammount` and `precision` and `description` is not required member, So it is null ( equal to size = 0 ) when its value is 0 .
So Asset has different size that nevertheless is has same `ledger_name`, `currency_name` and `domain_name`.
And I think it is dangerous to operate bang method for lmdb.

## Solution
One solution, `ammount` and `precision` change to `required` and erase `description`.

Would you solve this problem ?
Or Is it not serious ?

`May be erased comment` would be erased after merge or before merge.