### PR TITLE
Fix/commands peer remove

### DIFF
--- a/include/ametsuchi/ametsuchi.h
+++ b/include/ametsuchi/ametsuchi.h
@@ -109,6 +109,9 @@ class Ametsuchi {
                          const flatbuffers::String *asset_name,
                          bool uncommitted = false);
 
+  AM_val pubKeyGetPeer(const flatbuffers::String *pubKey,
+                       bool uncommitted = false);
+
   std::vector<AM_val> getAssetTransferBySender(
       const flatbuffers::String *senderKey, bool uncommitted = false);
 

--- a/include/ametsuchi/wsv.h
+++ b/include/ametsuchi/wsv.h
@@ -56,10 +56,13 @@ class WSV {
                          const flatbuffers::String *asset_name,
                          bool uncommitted = false, MDB_env *env = nullptr);
 
-
   std::vector<AM_val> accountGetAllAssets(const flatbuffers::String *pubKey,
                                           bool uncommitted = true,
                                           MDB_env *env = nullptr);
+
+  AM_val pubKeyGetPeer(const flatbuffers::String *pubKey,
+                       bool uncommitted = false, MDB_env *env = nullptr);
+
   /*
    * Get total number of trees
    */

--- a/schema/commands.fbs
+++ b/schema/commands.fbs
@@ -91,7 +91,7 @@ table PeerAdd {
 }
 
 table PeerRemove {
-    peer: [ubyte] (required, nested_flatbuffer: "Peer");
+    peerPubKey: string  (required);
 }
 
 // set new peer trust (with specific value)

--- a/src/ametsuchi/ametsuchi.cc
+++ b/src/ametsuchi/ametsuchi.cc
@@ -43,7 +43,6 @@ Ametsuchi::~Ametsuchi() {
 
 
 merkle::hash_t Ametsuchi::append(const std::vector<uint8_t> *blob) {
-
   // 1. Append to TX_store
   auto mt_root = tx_store.append(blob);
   // 2. Update WSV
@@ -180,6 +179,11 @@ AM_val Ametsuchi::accountGetAsset(const flatbuffers::String *pubKey,
                                   bool uncommitted) {
   return wsv.accountGetAsset(pubKey, ledger_name, domain_name, asset_name,
                              uncommitted, env);
+}
+
+AM_val Ametsuchi::pubKeyGetPeer(const flatbuffers::String *pubKey,
+                                bool uncommitted) {
+  return wsv.pubKeyGetPeer(pubKey, uncommitted, env);
 }
 
 std::vector<AM_val> Ametsuchi::getAssetTransferBySender(

--- a/src/ametsuchi/wsv.cc
+++ b/src/ametsuchi/wsv.cc
@@ -17,8 +17,8 @@
 
 #include <ametsuchi/comparator.h>
 #include <ametsuchi/currency.h>
-#include <transaction_generated.h>
 #include <ametsuchi/wsv.h>
+#include <transaction_generated.h>
 #include <iostream>
 
 namespace ametsuchi {
@@ -40,7 +40,8 @@ void WSV::init(MDB_txn *append_tx) {
       init_btree(append_tx_, "wsv_assetid_asset", MDB_CREATE);
 
   // [ip] => peer (NODUP)
-  trees_["wsv_pubkey_peer"] = init_btree(append_tx_, "wsv_pubkey_peer", MDB_CREATE);
+  trees_["wsv_pubkey_peer"] =
+      init_btree(append_tx_, "wsv_pubkey_peer", MDB_CREATE);
 
   // we should know created assets, so read entire table in memory
   read_created_assets();
@@ -419,12 +420,8 @@ void WSV::peer_remove(const iroha::PeerRemove *command) {
   c_key.mv_data = (void *)(pubkey->data());
   c_key.mv_size = pubkey->size();
 
-
-  std::cout << "WSV::peer_remove!" << std::endl;
-
   if ((res = mdb_cursor_get(cursor, &c_key, &c_val, MDB_SET))) {
     if (res == MDB_NOTFOUND) {
-      std::cout << "WSV::MDB_NOTFOUND" << std::endl;
       throw exception::InvalidTransaction::PEER_NOT_FOUND;
     }
 
@@ -568,6 +565,50 @@ std::vector<AM_val> WSV::accountGetAllAssets(const flatbuffers::String *pubKey,
     mdb_txn_abort(tx);
   }
   return ret;
+}
+
+AM_val WSV::pubKeyGetPeer(const flatbuffers::String *pubKey,
+                          bool uncommitted, MDB_env *env) {
+  MDB_val c_key, c_val;
+  MDB_cursor *cursor;
+  MDB_txn *tx;
+  int res;
+
+  // query peer by public key
+  c_key.mv_data = (void *)pubKey->data();
+  c_key.mv_size = pubKey->size();
+
+  if (uncommitted) {
+    cursor = trees_.at("wsv_pubkey_peer").second;
+    tx = append_tx_;
+  } else {
+    // create read-only transaction, create new RO cursor
+    if ((res = mdb_txn_begin(env, NULL, MDB_RDONLY, &tx))) {
+      AMETSUCHI_CRITICAL(res, MDB_PANIC);
+      AMETSUCHI_CRITICAL(res, MDB_MAP_RESIZED);
+      AMETSUCHI_CRITICAL(res, MDB_READERS_FULL);
+      AMETSUCHI_CRITICAL(res, ENOMEM);
+    }
+
+    if ((res = mdb_cursor_open(tx, trees_.at("wsv_pubkey_peer").first,
+                               &cursor))) {
+      AMETSUCHI_CRITICAL(res, EINVAL);
+    }
+  }
+
+  // if pubKey is not fount, throw exception
+  if ((res = mdb_cursor_get(cursor, &c_key, &c_val, MDB_SET))) {
+    if (res == MDB_NOTFOUND) {
+      throw exception::InvalidTransaction::PEER_NOT_FOUND;
+    }
+    AMETSUCHI_CRITICAL(res, EINVAL);
+  }
+
+  if (!uncommitted) {
+    mdb_cursor_close(cursor);
+    mdb_txn_abort(tx);
+  }
+  return AM_val(c_val);
 }
 
 void WSV::close_dbi(MDB_env *env) {

--- a/src/ametsuchi/wsv.cc
+++ b/src/ametsuchi/wsv.cc
@@ -39,7 +39,7 @@ void WSV::init(MDB_txn *append_tx) {
       init_btree(append_tx_, "wsv_assetid_asset", MDB_CREATE);
 
   // [ip] => peer (NODUP)
-  trees_["wsv_ip_peer"] = init_btree(append_tx_, "wsv_ip_peer", MDB_CREATE);
+  trees_["wsv_pubkey_peer"] = init_btree(append_tx_, "wsv_pubkey_peer", MDB_CREATE);
 
   // we should know created assets, so read entire table in memory
   read_created_assets();
@@ -381,17 +381,17 @@ void WSV::account_remove(const iroha::AccountRemove *command) {
 }
 
 void WSV::peer_add(const iroha::PeerAdd *command) {
-  MDB_cursor *cursor = trees_.at("wsv_ip_peer").second;
+  MDB_cursor *cursor = trees_.at("wsv_pubkey_peer").second;
   MDB_val c_key, c_val;
   int res;
 
   auto peer = flatbuffers::GetRoot<iroha::Peer>(command->peer()->data());
-  auto ip = peer->ip();
+  auto pubkey = peer->publicKey();
 
   flatbuffers::GetRoot<iroha::Peer>(peer);
 
-  c_key.mv_data = (void *)(ip->data());
-  c_key.mv_size = ip->size();
+  c_key.mv_data = (void *)(pubkey->data());
+  c_key.mv_size = pubkey->size();
   c_val.mv_data = (void *)command->peer()->data();
   c_val.mv_size = command->peer()->size();
 
@@ -409,19 +409,14 @@ void WSV::peer_add(const iroha::PeerAdd *command) {
 
 
 void WSV::peer_remove(const iroha::PeerRemove *command) {
-  auto cursor = trees_.at("wsv_ip_peer").second;
+  auto cursor = trees_.at("wsv_pubkey_peer").second;
   MDB_val c_key, c_val;
   int res;
 
-  auto peer = flatbuffers::GetRoot<iroha::Peer>(command->peer()->data());
-  auto ip = peer->ip();
+  auto pubkey = command->peerPubKey();
 
-  flatbuffers::GetRoot<iroha::Peer>(peer);
-
-  c_key.mv_data = (void *)(ip->data());
-  c_key.mv_size = ip->size();
-  c_val.mv_data = (void *)command->peer()->data();
-  c_val.mv_size = command->peer()->size();
+  c_key.mv_data = (void *)(pubkey->data());
+  c_key.mv_size = pubkey->size();
 
   if ((res = mdb_cursor_get(cursor, &c_key, &c_val, MDB_SET))) {
     if (res == MDB_NOTFOUND) {

--- a/src/ametsuchi/wsv.cc
+++ b/src/ametsuchi/wsv.cc
@@ -19,6 +19,7 @@
 #include <ametsuchi/currency.h>
 #include <transaction_generated.h>
 #include <ametsuchi/wsv.h>
+#include <iostream>
 
 namespace ametsuchi {
 
@@ -418,8 +419,12 @@ void WSV::peer_remove(const iroha::PeerRemove *command) {
   c_key.mv_data = (void *)(pubkey->data());
   c_key.mv_size = pubkey->size();
 
+
+  std::cout << "WSV::peer_remove!" << std::endl;
+
   if ((res = mdb_cursor_get(cursor, &c_key, &c_val, MDB_SET))) {
     if (res == MDB_NOTFOUND) {
+      std::cout << "WSV::MDB_NOTFOUND" << std::endl;
       throw exception::InvalidTransaction::PEER_NOT_FOUND;
     }
 

--- a/test/ametsuchi/ametsuchi.cc
+++ b/test/ametsuchi/ametsuchi.cc
@@ -224,3 +224,6 @@ TEST_F(Ametsuchi_Test, AssetTest) {
   }
   //});
 }
+
+TEST_F(Ametsuchi_Test, PeerTest) {
+}

--- a/test/ametsuchi/ametsuchi.cc
+++ b/test/ametsuchi/ametsuchi.cc
@@ -263,6 +263,35 @@ TEST_F(Ametsuchi_Test, PeerTest) {
     ametsuchi_.append(&blob);
   }
 
+  { // Check Peer1
+    flatbuffers::FlatBufferBuilder fbb(256);
+    auto tmp_pubkey = fbb.CreateString(pubkey1);
+    fbb.Finish(tmp_pubkey);
+    auto query_pubkey = flatbuffers::GetRoot<flatbuffers::String>(fbb.GetBufferPointer());
+
+    auto cur = flatbuffers::GetRoot<iroha::Peer>(
+        ametsuchi_
+            .pubKeyGetPeer(query_pubkey,true)
+            .data);
+
+    ASSERT_TRUE(cur->publicKey()->str() == pubkey1);
+    ASSERT_TRUE(cur->ip()->str() ==  ip1);
+  }
+
+  { // Check Peer2
+    flatbuffers::FlatBufferBuilder fbb(256);
+    auto tmp_pubkey = fbb.CreateString(pubkey2);
+    fbb.Finish(tmp_pubkey);
+    auto query_pubkey = flatbuffers::GetRoot<flatbuffers::String>(fbb.GetBufferPointer());
+
+    auto cur = flatbuffers::GetRoot<iroha::Peer>(
+        ametsuchi_
+            .pubKeyGetPeer(query_pubkey,true)
+            .data);
+
+    ASSERT_TRUE(cur->publicKey()->str() == pubkey2);
+    ASSERT_TRUE(cur->ip()->str() ==  ip2);
+  }
 
   {  // Remove peer1
     flatbuffers::FlatBufferBuilder fbb(2048);
@@ -272,12 +301,42 @@ TEST_F(Ametsuchi_Test, PeerTest) {
     ametsuchi_.append(&blob);
   }
 
-  {  // Remove peer1
+  { // Check Peer1
+    flatbuffers::FlatBufferBuilder fbb(256);
+    auto tmp_pubkey = fbb.CreateString(pubkey1);
+    fbb.Finish(tmp_pubkey);
+    auto query_pubkey = flatbuffers::GetRoot<flatbuffers::String>(fbb.GetBufferPointer());
+
+    bool exception_flag = false;
+    try {
+        ametsuchi_.pubKeyGetPeer(query_pubkey, true);
+    } catch ( ... ) {
+      exception_flag = true;
+    }
+    ASSERT_TRUE( exception_flag );
+  }
+
+  {  // Remove peer2
     flatbuffers::FlatBufferBuilder fbb(2048);
     auto blob = generator::random_transaction(
         fbb, iroha::Command::PeerRemove,
         generator::random_PeerRemove(fbb, pubkey2).Union());
     ametsuchi_.append(&blob);
+  }
+
+  { // Check Peer2
+    flatbuffers::FlatBufferBuilder fbb(256);
+    auto tmp_pubkey = fbb.CreateString(pubkey2);
+    fbb.Finish(tmp_pubkey);
+    auto query_pubkey = flatbuffers::GetRoot<flatbuffers::String>(fbb.GetBufferPointer());
+
+    bool exception_flag = false;
+    try {
+      ametsuchi_.pubKeyGetPeer(query_pubkey, true);
+    } catch ( ... ) {
+      exception_flag = true;
+    }
+    ASSERT_TRUE( exception_flag );
   }
 
   ametsuchi_.commit();

--- a/test/ametsuchi/ametsuchi.cc
+++ b/test/ametsuchi/ametsuchi.cc
@@ -16,11 +16,12 @@
  */
 
 #include <ametsuchi/ametsuchi.h>
-#include <transaction_generated.h>
 #include <flatbuffers/flatbuffers.h>
 #include <gtest/gtest.h>
 #include <spdlog/spdlog.h>
+#include <transaction_generated.h>
 #include "../generator/tx_generator.h"
+#include <iostream>
 
 class Ametsuchi_Test : public ::testing::Test {
  protected:
@@ -33,7 +34,7 @@ class Ametsuchi_Test : public ::testing::Test {
 };
 
 TEST_F(Ametsuchi_Test, AssetTest) {
-    // ASSERT_NO_THROW({
+  // ASSERT_NO_THROW({
   flatbuffers::FlatBufferBuilder fbb(2048);
 
   // Create asset dollar
@@ -45,54 +46,52 @@ TEST_F(Ametsuchi_Test, AssetTest) {
   // Create account with id 1
   blob = generator::random_transaction(
       fbb, iroha::Command::AccountAdd,
-      generator::random_AccountAdd(fbb, generator::random_account("1")).Union()
-  );
+      generator::random_AccountAdd(fbb, generator::random_account("1"))
+          .Union());
   ametsuchi_.append(&blob);
 
   // Create account with id 2
   blob = generator::random_transaction(
       fbb, iroha::Command::AccountAdd,
-      generator::random_AccountAdd(fbb, generator::random_account("2")).Union()
-  );
+      generator::random_AccountAdd(fbb, generator::random_account("2"))
+          .Union());
   ametsuchi_.append(&blob);
 
   // Add currency to account 1
   blob = generator::random_transaction(
       fbb, iroha::Command::AssetAdd,
       generator::random_AssetAdd(
-          fbb, "1",
-          generator::random_asset_wrapper_currency(200,
-                                                   2,
-                                                   "Dollar",
-                                                   "USA",
-                                                   "l1")).Union()
-  );
+          fbb, "1", generator::random_asset_wrapper_currency(200, 2, "Dollar",
+                                                             "USA", "l1"))
+          .Union());
   ametsuchi_.append(&blob);
 
   {
     flatbuffers::FlatBufferBuilder fbb2(2048);
-    auto reference_tx = flatbuffers::GetRoot<iroha::Transaction>(generator::random_transaction(
-        fbb2, iroha::Command::AssetTransfer,
-        generator::random_AssetTransfer(
-            fbb2,
-            generator::random_asset_wrapper_currency(100,
-                                                     2,
-                                                     "Dollar",
-                                                     "USA",
-                                                     "l1"),
-            "1", "2").Union()
-    ).data())->command_as_AssetTransfer();
+    auto reference_tx =
+        flatbuffers::GetRoot<iroha::Transaction>(
+            generator::random_transaction(
+                fbb2, iroha::Command::AssetTransfer,
+                generator::random_AssetTransfer(
+                    fbb2, generator::random_asset_wrapper_currency(
+                              100, 2, "Dollar", "USA", "l1"),
+                    "1", "2")
+                    .Union())
+                .data())
+            ->command_as_AssetTransfer();
     auto reference_1 = reference_tx->sender();
-    auto reference_ln = reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
-    auto reference_dn = reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
-    auto reference_cn = reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
-    auto cur =
-        flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
-            reference_1,
-            reference_ln,
-            reference_dn,
-            reference_cn,
-            true).data)->asset_as_Currency();
+    auto reference_ln =
+        reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
+    auto reference_dn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
+    auto reference_cn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
+    auto cur = flatbuffers::GetRoot<iroha::Asset>(
+                   ametsuchi_
+                       .accountGetAsset(reference_1, reference_ln, reference_dn,
+                                        reference_cn, true)
+                       .data)
+                   ->asset_as_Currency();
 
     ASSERT_EQ(cur->amount(), 200);
   }
@@ -100,69 +99,69 @@ TEST_F(Ametsuchi_Test, AssetTest) {
   // Transfer from 1 to 2
   blob = generator::random_transaction(
       fbb, iroha::Command::AssetTransfer,
-      generator::random_AssetTransfer(
-          fbb,
-          generator::random_asset_wrapper_currency(100,
-                                                   2,
-                                                   "Dollar",
-                                                   "USA",
-                                                   "l1"),
-          "1", "2").Union()
-  );
+      generator::random_AssetTransfer(fbb,
+                                      generator::random_asset_wrapper_currency(
+                                          100, 2, "Dollar", "USA", "l1"),
+                                      "1", "2")
+          .Union());
   ametsuchi_.append(&blob);
 
   {
     flatbuffers::FlatBufferBuilder fbb2(2048);
-    auto reference_tx = flatbuffers::GetRoot<iroha::Transaction>(generator::random_transaction(
-        fbb2, iroha::Command::AssetTransfer,
-        generator::random_AssetTransfer(
-            fbb2,
-            generator::random_asset_wrapper_currency(100,
-                                                     2,
-                                                     "Dollar",
-                                                     "USA",
-                                                     "l1"),
-            "1", "2").Union()
-    ).data())->command_as_AssetTransfer();
+    auto reference_tx =
+        flatbuffers::GetRoot<iroha::Transaction>(
+            generator::random_transaction(
+                fbb2, iroha::Command::AssetTransfer,
+                generator::random_AssetTransfer(
+                    fbb2, generator::random_asset_wrapper_currency(
+                              100, 2, "Dollar", "USA", "l1"),
+                    "1", "2")
+                    .Union())
+                .data())
+            ->command_as_AssetTransfer();
     auto reference_1 = reference_tx->sender();
-    auto reference_ln = reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
-    auto reference_dn = reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
-    auto reference_cn = reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
-    auto cur =
-        flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
-            reference_1,
-            reference_ln,
-            reference_dn,
-            reference_cn,
-            true).data)->asset_as_Currency();
+    auto reference_ln =
+        reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
+    auto reference_dn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
+    auto reference_cn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
+    auto cur = flatbuffers::GetRoot<iroha::Asset>(
+                   ametsuchi_
+                       .accountGetAsset(reference_1, reference_ln, reference_dn,
+                                        reference_cn, true)
+                       .data)
+                   ->asset_as_Currency();
 
     ASSERT_EQ(cur->amount(), 100);
   }
 
   {
     flatbuffers::FlatBufferBuilder fbb2(2048);
-    auto reference_tx = flatbuffers::GetRoot<iroha::Transaction>(generator::random_transaction(
-        fbb2, iroha::Command::AssetTransfer,
-        generator::random_AssetTransfer(
-            fbb2,
-            generator::random_asset_wrapper_currency(100,
-                                                     2,
-                                                     "Dollar",
-                                                     "USA",
-                                                     "l1"),
-            "1", "2").Union()
-    ).data())->command_as_AssetTransfer();
+    auto reference_tx =
+        flatbuffers::GetRoot<iroha::Transaction>(
+            generator::random_transaction(
+                fbb2, iroha::Command::AssetTransfer,
+                generator::random_AssetTransfer(
+                    fbb2, generator::random_asset_wrapper_currency(
+                              100, 2, "Dollar", "USA", "l1"),
+                    "1", "2")
+                    .Union())
+                .data())
+            ->command_as_AssetTransfer();
     auto reference_2 = reference_tx->receiver();
-    auto reference_ln = reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
-    auto reference_dn = reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
-    auto reference_cn = reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
-    auto cur =
-        flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
-            reference_2,
-            reference_ln,
-            reference_dn,
-            reference_cn,
-            true).data)->asset_as_Currency();
+    auto reference_ln =
+        reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
+    auto reference_dn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
+    auto reference_cn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
+    auto cur = flatbuffers::GetRoot<iroha::Asset>(
+                   ametsuchi_
+                       .accountGetAsset(reference_2, reference_ln, reference_dn,
+                                        reference_cn, true)
+                       .data)
+                   ->asset_as_Currency();
 
     ASSERT_EQ(cur->amount(), 100);
   }
@@ -171,59 +170,115 @@ TEST_F(Ametsuchi_Test, AssetTest) {
 
   {
     flatbuffers::FlatBufferBuilder fbb2(2048);
-    auto reference_tx = flatbuffers::GetRoot<iroha::Transaction>(generator::random_transaction(
-        fbb2, iroha::Command::AssetTransfer,
-        generator::random_AssetTransfer(
-            fbb2,
-            generator::random_asset_wrapper_currency(100,
-                                                     2,
-                                                     "Dollar",
-                                                     "USA",
-                                                     "l1"),
-            "1", "2").Union()
-    ).data())->command_as_AssetTransfer();
+    auto reference_tx =
+        flatbuffers::GetRoot<iroha::Transaction>(
+            generator::random_transaction(
+                fbb2, iroha::Command::AssetTransfer,
+                generator::random_AssetTransfer(
+                    fbb2, generator::random_asset_wrapper_currency(
+                              100, 2, "Dollar", "USA", "l1"),
+                    "1", "2")
+                    .Union())
+                .data())
+            ->command_as_AssetTransfer();
     auto reference_1 = reference_tx->sender();
-    auto reference_ln = reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
-    auto reference_dn = reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
-    auto reference_cn = reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
-    auto cur =
-        flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
-            reference_1,
-            reference_ln,
-            reference_dn,
-            reference_cn).data)->asset_as_Currency();
+    auto reference_ln =
+        reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
+    auto reference_dn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
+    auto reference_cn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
+    auto cur = flatbuffers::GetRoot<iroha::Asset>(
+                   ametsuchi_
+                       .accountGetAsset(reference_1, reference_ln, reference_dn,
+                                        reference_cn)
+                       .data)
+                   ->asset_as_Currency();
 
     ASSERT_EQ(cur->amount(), 100);
   }
 
   {
     flatbuffers::FlatBufferBuilder fbb2(2048);
-    auto reference_tx = flatbuffers::GetRoot<iroha::Transaction>(generator::random_transaction(
-        fbb2, iroha::Command::AssetTransfer,
-        generator::random_AssetTransfer(
-            fbb2,
-            generator::random_asset_wrapper_currency(100,
-                                                     2,
-                                                     "Dollar",
-                                                     "USA",
-                                                     "l1"),
-            "1", "2").Union()
-    ).data())->command_as_AssetTransfer();
+    auto reference_tx =
+        flatbuffers::GetRoot<iroha::Transaction>(
+            generator::random_transaction(
+                fbb2, iroha::Command::AssetTransfer,
+                generator::random_AssetTransfer(
+                    fbb2, generator::random_asset_wrapper_currency(
+                              100, 2, "Dollar", "USA", "l1"),
+                    "1", "2")
+                    .Union())
+                .data())
+            ->command_as_AssetTransfer();
     auto reference_2 = reference_tx->receiver();
-    auto reference_ln = reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
-    auto reference_dn = reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
-    auto reference_cn = reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
-    auto cur =
-        flatbuffers::GetRoot<iroha::Asset>(ametsuchi_.accountGetAsset(
-            reference_2,
-            reference_ln,
-            reference_dn,
-            reference_cn).data)->asset_as_Currency();
+    auto reference_ln =
+        reference_tx->asset_nested_root()->asset_as_Currency()->ledger_name();
+    auto reference_dn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->domain_name();
+    auto reference_cn =
+        reference_tx->asset_nested_root()->asset_as_Currency()->currency_name();
+    auto cur = flatbuffers::GetRoot<iroha::Asset>(
+                   ametsuchi_
+                       .accountGetAsset(reference_2, reference_ln, reference_dn,
+                                        reference_cn)
+                       .data)
+                   ->asset_as_Currency();
 
     ASSERT_EQ(cur->amount(), 100);
   }
+
   //});
 }
 
 TEST_F(Ametsuchi_Test, PeerTest) {
+  std::string pubkey1 = "SOULCATCHER_S";
+  std::string ip1 = "KamineShota";
+  std::string pubkey2 = "LIGHTWING";
+  std::string ip2 = "AmagaiRihito";
+
+
+  // Create asset dollar
+  /*
+ auto blob = generator::random_transaction
+     fbb, iroha::Command::AssetCreate,
+     generator::random_AssetCreate(fbb, "Dollar", "USA", "l1").Union());
+ */
+
+  {  // Create peer1
+    flatbuffers::FlatBufferBuilder fbb(2048);
+    auto blob = generator::random_transaction(
+        fbb, iroha::Command::PeerAdd,
+        generator::random_PeerAdd(fbb, generator::random_peer(pubkey1, ip1))
+            .Union());
+    ametsuchi_.append(&blob);
+  }
+
+  {  // Create peer2
+    flatbuffers::FlatBufferBuilder fbb(2048);
+    auto blob = generator::random_transaction(
+        fbb, iroha::Command::PeerAdd,
+        generator::random_PeerAdd(fbb, generator::random_peer(pubkey2, ip2))
+            .Union());
+    ametsuchi_.append(&blob);
+  }
+
+
+  {  // Remove peer1
+    flatbuffers::FlatBufferBuilder fbb(2048);
+    auto blob = generator::random_transaction(
+        fbb, iroha::Command::PeerRemove,
+        generator::random_PeerRemove(fbb, pubkey1).Union());
+    ametsuchi_.append(&blob);
+  }
+
+  {  // Remove peer1
+    flatbuffers::FlatBufferBuilder fbb(2048);
+    auto blob = generator::random_transaction(
+        fbb, iroha::Command::PeerRemove,
+        generator::random_PeerRemove(fbb, pubkey2).Union());
+    ametsuchi_.append(&blob);
+  }
+
+  ametsuchi_.commit();
 }

--- a/test/generator/tx_generator.h
+++ b/test/generator/tx_generator.h
@@ -269,8 +269,8 @@ flatbuffers::Offset<iroha::PeerAdd> random_PeerAdd(
 
 flatbuffers::Offset<iroha::PeerRemove> random_PeerRemove(
     flatbuffers::FlatBufferBuilder& fbb,
-    std::vector<uint8_t> peer = random_peer()) {
-  return iroha::CreatePeerRemove(fbb, fbb.CreateVector(peer));
+    std::string pubkey = random_string(10)) {
+  return iroha::CreatePeerRemove(fbb, fbb.CreateString(pubkey));
 }
 
 /**


### PR DESCRIPTION
Change PeerRemove table in `commands.fbs`

- PeerRemove 
    - Before  table PeerRemove {     peer: [ubyte] (required, nested_flatbuffer: "Peer"); } 
    - After  table PeerRemove {     peerPubKey: string   (required); }

With this additonal function `pubKeyGetPeer()` in `ametsuchi.h`.

Would you review and if no probme, merge it ?